### PR TITLE
avsmodule

### DIFF
--- a/nexuscore/nexus_avs_module/.cargo/config
+++ b/nexuscore/nexus_avs_module/.cargo/config
@@ -1,0 +1,4 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"
+wasm-debug = "build --target wasm32-unknown-unknown"
+schema = "run --example schema"

--- a/nexuscore/nexus_avs_module/Cargo.toml
+++ b/nexuscore/nexus_avs_module/Cargo.toml
@@ -1,0 +1,58 @@
+[package]
+name = "nexus_avs_module"
+version = "0.1.0"
+edition = "2021"
+
+exclude = [
+  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+  "contract.wasm",
+  "hash.txt",
+]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[profile.release]
+opt-level = 3
+debug = false
+rpath = false
+lto = true
+debug-assertions = false
+codegen-units = 1
+panic = 'abort'
+incremental = false
+overflow-checks = true
+
+[features]
+# for quicker tests, cargo test --lib
+# for more explicit tests, cargo test --features=backtraces
+backtraces = ["cosmwasm-std/backtraces"]
+library = []
+
+[dependencies]
+rand = "0.5.0"
+nexus_rewards_dispatcher = {path = "../nexus_rewards_dispatcher", features = ["library"] }
+signed_integers = { path = "../../packages/signed_integers", default-features = false, version = "0.1.0"}
+nexus_validator_registary = {path = "../nexus_validator_registary", features = ["library"]}
+cw2 = { version = "1.1.0" }
+cw20 = { version = "1.1.0" }
+cw20-base = { version = "1.1.0", features = ["library"] }
+snafu = { version = "0.6.3" }
+basset = { path = "../../packages/basset", default-features = false, version = "0.1.0"}
+cosmwasm-storage = { version = "1.5.2",features = ["iterator"]}
+cosmwasm-std = { version = "1.5.3", features = ["staking"] }
+serde = { version = "1.0.197", default-features = false, features = ["derive"] }
+cw-storage-plus = {version="0.16.0",features = ["iterator"]}
+thiserror = "1.0.58"
+nibiru-std = "0.0.3"
+schemars = "0.8.20"
+cosmwasm-schema = "2.0.3"
+cw-ownable = "0.5.1"
+serde_json = "1.0.117"
+# [dev-dependencies]
+# cosmwasm-vm = { version = "0.16.0", default-features = false, features = ["iterator"] }
+# cosmwasm-schema = { version = "0.16.0", default-features = false  }
+
+

--- a/nexuscore/nexus_avs_module/src/contract.rs
+++ b/nexuscore/nexus_avs_module/src/contract.rs
@@ -1,0 +1,103 @@
+use cosmwasm_schema::Api;
+use cosmwasm_std::{
+    entry_point, to_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult, Uint128
+};
+// use cw2::set_contract_version;
+use cw_storage_plus::{Item, Map};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use crate::{msg::{State,Operator,InstantiateMsg,OperatorDetails,ExecuteMsg,SignatureWithExpiry,Withdrawal}};
+
+#[entry_point]
+
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    msg: InstantiateMsg,
+) -> StdResult<Response> {
+    let operator_details = OperatorDetails {
+        earnings_receiver: Addr::unchecked(&msg.initial_owner),
+        delegation_approver: None,
+        metadata_uri: "none".to_string()
+    };
+    OPERATOR_DETAILS.save(deps.storage, &operator_details)?;
+
+    Ok(Response::new()
+        .add_attribute("method", "instantiate")
+        .add_attribute("owner", info.sender))
+}
+
+
+#[entry_point]
+pub fn execute(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> StdResult<Response> {
+    match msg {
+        ExecuteMsg::RegisterAsOperator { details, metadata_uri } => {
+            register_as_operator(deps, info, details, metadata_uri)
+        }
+      
+    }
+}
+
+pub fn register_as_operator(
+    deps: DepsMut,
+    info: MessageInfo,
+    details: OperatorDetails,
+    metadata_uri: String,
+) -> StdResult<Response> {
+    let operator = Operator {
+        details,
+        is_registered: true,
+    };
+    OPERATORS.save(deps.storage, &info.sender, &operator)?;
+    Ok(Response::new().add_attribute("method", "register_as_operator"))
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::GetOperatorsForDelegation {} => {
+            let mut validators = query_validators(deps)?;
+            validators.sort_by(|v1, v2| v1.total_delegated.cmp(&v2.total_delegated));
+            to_binary(&validators)
+        }
+        QueryMsg::Config {} => to_binary(&query_config(deps)?),
+    }
+}
+
+fn query_validators(deps: Deps) -> StdResult<Vec<ValidatorResponse>> {
+    let config = CONFIG.load(deps.storage)?;
+    let hub_address = config.hub_contract;
+
+    let mut delegations = HashMap::new();
+    for delegation in deps.querier.query_all_delegations(&hub_address)? {
+        delegations.insert(delegation.validator, delegation.amount.amount);
+    }
+
+    let mut validators: Vec<ValidatorResponse> = vec![];
+    for item in REGISTRY.range(deps.storage, None, None, cosmwasm_std::Order::Ascending) {
+        let mut validator = ValidatorResponse {
+            total_delegated: Default::default(),
+            address: item?.1.address,
+        };
+        // TODO: check that cosmos cosmwasm module has this bug or not
+        // There is a bug in terra/core.
+        // The bug happens when we do query_delegation() but there are no delegation pair (delegator-validator)
+        // but query_delegation() fails with a parse error cause terra/core returns an empty FullDelegation struct
+        // instead of a nil pointer to the struct.
+        // https://github.com/terra-money/core/blob/58602320d2907814cfccdf43e9679468bb4bd8d3/x/staking/wasm/interface.go#L227
+        // So we do query_all_delegations() instead of query_delegation().unwrap()
+        // and try to find delegation in the returned vec
+        validator.total_delegated = *delegations
+            .get(&validator.address)
+            .unwrap_or(&Uint128::zero());
+        validators.push(validator);
+    }
+    Ok(validators)
+}

--- a/nexuscore/nexus_avs_module/src/lib.rs
+++ b/nexuscore/nexus_avs_module/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/nexuscore/nexus_avs_module/src/msg.rs
+++ b/nexuscore/nexus_avs_module/src/msg.rs
@@ -1,0 +1,24 @@
+
+
+use std::collections::HashMap;
+
+use cosmwasm_std::{Addr,Binary, Uint128};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use cosmwasm_schema::cw_serde;
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct OperatorDetails {
+    pub earnings_receiver: Addr,
+    pub delegation_approver: Option<Addr>,
+    pub metadata_uri: String,
+}
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct Operator {
+    pub details: OperatorDetails,
+    pub is_registered: bool,
+}
+pub const STATE: Item<State> = Item::new("state");
+pub const OPERATORS: Map<&Addr, Operator> = Map::new("operators");
+pub const DELEGATIONS: Map<&Addr, Addr> = Map::new("delegations");
+static OPERATOR_DETAILS: Item<OperatorDetails> = Item::new("operator_details");


### PR DESCRIPTION
adding avs module

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds wasm build aliases, new functions for operator management, and query methods to the `nexus_avs_module`.

### Detailed summary
- Added wasm build aliases in `.cargo/config`
- Implemented `add` function in `lib.rs`
- Defined `OperatorDetails` and `Operator` structs in `msg.rs`
- Added storage items and maps in `msg.rs`
- Implemented `instantiate` and `execute` entry points in `contract.rs`
- Added query method `query` in `contract.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->